### PR TITLE
[query] fix undefined claimable filter condition

### DIFF
--- a/src/stream/query.ts
+++ b/src/stream/query.ts
@@ -170,7 +170,7 @@ function isStreamOfQuery(stream: IStream, query: IncomingStreamQuery | OutgoingS
     return true;
   }
   const isStatus = isStreamOfStatus(stream, query.status);
-  if (query && 'claimable' in query) {
+  if (query && 'claimable' in query && query.claimable !== undefined) {
     const isClaimable = query.claimable ? stream.progress.claimable !== 0n : stream.progress.claimable === 0n;
     return isStatus && isClaimable;
   }

--- a/test/unit/stream/client.test.ts
+++ b/test/unit/stream/client.test.ts
@@ -28,10 +28,22 @@ describe('MPayClient', () => {
       claimable: true,
     });
     const res = await getAllFromIter(it);
+    expect(res.length).toBeGreaterThan(0);
     for (let i = 0; i !== res.length; i++) {
       const st = res[i];
       expect(st.progress.claimable).toBeGreaterThan(0);
     }
+  });
+
+  it('Undefined claimable shall return all', async () => {
+    const it = await client.getIncomingStreams({
+      claimable: undefined,
+    });
+    const res = await getAllFromIter(it);
+    expect(res.length).toBeGreaterThan(0);
+    res.forEach((st) => {
+      console.log(st.progress.claimable);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Fix the search condition where claimable is undefined.

Now the list will return all streams when claimable is undefined. 

### Backward compatibility

Yes

## Test

Tested manually by adding a test case.