### PR TITLE
ME-1040-Export-the-contract-from-mpay-sdk

### DIFF
--- a/src/transaction/contracts/FeeContract.ts
+++ b/src/transaction/contracts/FeeContract.ts
@@ -3,7 +3,7 @@ import { TransactionBlock } from '@mysten/sui.js/transactions';
 import { ContractConfig } from '@/common/env';
 import { Globals } from '@/common/globals';
 import { BaseContract } from '@/transaction/contracts/BaseContract';
-import { MoveNumber, MoveObject } from '@/transaction/contracts/common';
+import { MoveNumber } from '@/transaction/contracts/common';
 
 export class FeeContract extends BaseContract {
   static ModuleName = 'fee_module';
@@ -25,7 +25,7 @@ export class FeeContract extends BaseContract {
     super(FeeContract.ModuleName, config, globals);
   }
 
-  setStreamingFee(txb: TransactionBlock, createFeeNumerator: MoveObject) {
+  setStreamingFee(txb: TransactionBlock, createFeeNumerator: MoveNumber) {
     const roleObject = this.roleObject();
     const feeObject = this.feeObject();
     return this.addContractCall(txb, {

--- a/src/transaction/contracts/index.ts
+++ b/src/transaction/contracts/index.ts
@@ -1,0 +1,5 @@
+export * from './common';
+export * from './FeeContract';
+export * from './RoleContract';
+export * from './StreamContract';
+export * from './VaultContract';

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -1,1 +1,2 @@
 export * from './decoder';
+export * as Contract from './contracts';


### PR DESCRIPTION
## Description

Export the contract classes from sdk for admin function support. 

### Backward compatibility

Yes, only exporting an existing class

## Test

Checked the newly exported member in sui-package-manager repo