### PR TITLE
[query] add a filter in incoming stream

### DIFF
--- a/src/stream/query.ts
+++ b/src/stream/query.ts
@@ -114,7 +114,8 @@ export class StreamListRequester {
     const backendQuery = convertToIncomingBackendQuery(input.query);
     const recipient = await input.globals.walletAddress();
     const refs = await input.globals.backend.getIncomingStreams(recipient, backendQuery);
-    const groupedRefs = groupAndSortRefs(refs);
+    const filtered = refs.filter((ref) => normalizeSuiAddress(ref.recipient) === normalizeSuiAddress(recipient));
+    const groupedRefs = groupAndSortRefs(filtered);
 
     return new StreamListRequester(input.globals, recipient, groupedRefs, input.query);
   }


### PR DESCRIPTION
## Description

Add an additional filter to incoming stream filter. 

Incoming stream filter shall strictly have recipient as the recipient, not with the stream group. 

## Test

Test failed due to backend environment 502. Merge for now. 